### PR TITLE
fix: prevent shell injection in git commands via execFile

### DIFF
--- a/src/modules/GitCommands.ts
+++ b/src/modules/GitCommands.ts
@@ -1,4 +1,3 @@
-import { exec } from 'child_process';
 import {
   GitCommandNamesEnum,
   GitCommandsEnum,
@@ -7,34 +6,28 @@ import { childExecAsync, childExecSync } from '../utils/exec.utils';
 import { logger } from '../core/logger';
 
 export class GitCommandsManager {
-  static [GitCommandNamesEnum.add](...files: string[]) {
-    return `${GitCommandsEnum[GitCommandNamesEnum.add]} ${files.join(' ')}`;
+  static [GitCommandNamesEnum.add](...files: string[]): string[] {
+    return [...GitCommandsEnum[GitCommandNamesEnum.add].split(' '), '--', ...files];
   }
 
-  static [GitCommandNamesEnum.addForce](...files: string[]) {
-    return `${GitCommandsEnum[GitCommandNamesEnum.addForce]} ${files.join(
-      ' '
-    )}`;
+  static [GitCommandNamesEnum.addForce](...files: string[]): string[] {
+    return [...GitCommandsEnum[GitCommandNamesEnum.addForce].split(' '), '--', ...files];
   }
 
-  static [GitCommandNamesEnum.assumeUnchanged](...files: string[]) {
-    return `${
-      GitCommandsEnum[GitCommandNamesEnum.assumeUnchanged]
-    } ${files.join(' ')}`;
+  static [GitCommandNamesEnum.assumeUnchanged](...files: string[]): string[] {
+    return [...GitCommandsEnum[GitCommandNamesEnum.assumeUnchanged].split(' '), '--', ...files];
   }
 
-  static [GitCommandNamesEnum.noAssumeUnchanged](...files: string[]) {
-    return `${
-      GitCommandsEnum[GitCommandNamesEnum.noAssumeUnchanged]
-    } ${files.join(' ')}`;
+  static [GitCommandNamesEnum.noAssumeUnchanged](...files: string[]): string[] {
+    return [...GitCommandsEnum[GitCommandNamesEnum.noAssumeUnchanged].split(' '), '--', ...files];
   }
 
-  static [GitCommandNamesEnum.checkInitialized]() {
-    return GitCommandsEnum[GitCommandNamesEnum.checkInitialized];
+  static [GitCommandNamesEnum.checkInitialized](): string[] {
+    return GitCommandsEnum[GitCommandNamesEnum.checkInitialized].split(' ');
   }
 
-  static [GitCommandNamesEnum.status]() {
-    return GitCommandsEnum[GitCommandNamesEnum.status];
+  static [GitCommandNamesEnum.status](): string[] {
+    return GitCommandsEnum[GitCommandNamesEnum.status].split(' ');
   }
 
   static async execAsync(
@@ -42,11 +35,11 @@ export class GitCommandsManager {
     cwd?: string,
     ...args: string[]
   ) {
-    return childExecAsync(this.gitCommand(command, ...args), { cwd });
+    return childExecAsync('git', this.gitCommand(command, ...args), { cwd });
   }
 
   static exec(command: GitCommandNamesEnum, cwd?: string, ...args: string[]) {
-    return childExecSync(this.gitCommand(command, ...args), { cwd });
+    return childExecSync('git', this.gitCommand(command, ...args), { cwd });
   }
 
   static async tryExecAsyncGitCommand(
@@ -59,7 +52,7 @@ export class GitCommandsManager {
     error?: Error;
   }> {
     logger.appendLine(
-      'Executing command: ' + this.gitCommand(command, ...args)
+      'Executing command: git ' + this.gitCommand(command, ...args).join(' ')
     );
 
     if (command === GitCommandNamesEnum.assumeUnchanged) {
@@ -88,11 +81,11 @@ export class GitCommandsManager {
   private static gitCommand(
     command: GitCommandNamesEnum,
     ...args: string[]
-  ): string {
+  ): string[] {
     if (!(this as any)[command]) {
       throw new Error(`Git command ${command} not found`);
     }
 
-    return `git ${(this as any)[command]?.(...args)}`;
+    return (this as any)[command]?.(...args);
   }
 }

--- a/src/modules/GitCommands.ts
+++ b/src/modules/GitCommands.ts
@@ -51,9 +51,10 @@ export class GitCommandsManager {
     result?: string;
     error?: Error;
   }> {
-    logger.appendLine(
-      'Executing command: git ' + this.gitCommand(command, ...args).join(' ')
-    );
+    const printableArgv = this.gitCommand(command, ...args)
+      .map((arg) => (/\s/.test(arg) ? `"${arg}"` : arg))
+      .join(' ');
+    logger.appendLine('Executing command: git ' + printableArgv);
 
     if (command === GitCommandNamesEnum.assumeUnchanged) {
       return {

--- a/src/modules/GitManager.ts
+++ b/src/modules/GitManager.ts
@@ -1,11 +1,11 @@
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { WorkspaceManager } from './WorkspaceManager';
 import { addGitToPath } from '../utils/string.utils';
 
 export class GitManager {
   static isGitInitialized(path?: string) {
     try {
-      execSync('git rev-parse --is-inside-work-tree', {
+      execFileSync('git', ['rev-parse', '--is-inside-work-tree'], {
         encoding: 'utf-8',
         cwd: path,
       });

--- a/src/utils/exec.utils.ts
+++ b/src/utils/exec.utils.ts
@@ -1,12 +1,14 @@
-import { ExecException, exec, execSync } from 'child_process';
+import { execFile, execFileSync } from 'child_process';
 
 export const childExecAsync = (
   command: string,
+  args: string[],
   options: { cwd?: string; encoding?: BufferEncoding } = {}
 ): Promise<string> => {
   return new Promise((resolve, reject) => {
-    exec(
+    execFile(
       command,
+      args,
       { cwd: options.cwd, encoding: options.encoding || 'utf-8' },
       (error, stdout, stderr) => {
         if (error) {
@@ -22,12 +24,13 @@ export const childExecAsync = (
 
 export const childExecSync = (
   command: string,
+  args: string[],
   options: {
     cwd?: string;
     encoding?: BufferEncoding;
   } = {}
 ): string => {
-  const stdout = execSync(command, {
+  const stdout = execFileSync(command, args, {
     cwd: options.cwd,
     encoding: options.encoding || 'utf-8',
   });


### PR DESCRIPTION
## Problem
Git commands were assembled by string concatenation and executed through a shell (`exec` / `execSync`). User/repo-controlled file paths (from the working tree and changelists) were interpolated **unquoted** into the command string, so a path containing shell metacharacters (e.g. `$(...)`, `;`, backticks) could inject arbitrary commands when a file was added to / staged / removed from a changelist. Paths containing spaces also broke the commands.

## Fix
- **`exec.utils.ts`** — run git via `execFile` / `execFileSync` with an **argv array** instead of a shell command string. No shell ⇒ paths are never interpreted.
- **`GitCommands.ts`** — build each command as an argument array instead of a concatenated string, and insert a `--` separator before file paths so a path starting with `-` can't be parsed as a flag.
- **`GitManager.ts`** — route the remaining `rev-parse` call through `execFileSync` as well, so no shell-string git execution remains anywhere.

No behavior change for normal paths; fixes both the injection vector and breakage on paths with spaces. (Already gated by VS Code Workspace Trust, but worth fixing regardless.)

## Verification
`tsc -p ./` type-checks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
